### PR TITLE
fix 'no method matching parse' error

### DIFF
--- a/src/rw_1d_stat_main.jl
+++ b/src/rw_1d_stat_main.jl
@@ -1,8 +1,8 @@
 include("rw_1d_stat.jl")
 
-num = length(ARGS)>0 ? parse(ARGS[1]) : 1000
-nsteps = length(ARGS)>1 ? parse(ARGS[2]) : 1000
-prob = length(ARGS)>2 ? parse(ARGS[3]) : 0.5
+num = length(ARGS)>0 ? parse(Int, ARGS[1]) : 1000
+nsteps = length(ARGS)>1 ? parse(Int, ARGS[2]) : 1000
+prob = length(ARGS)>2 ? parse(Float64, ARGS[3]) : 0.5
 filename = length(ARGS)>3 ? ARGS[4] : ""
 
 if isempty(filename)

--- a/src/rw_stat_main.jl
+++ b/src/rw_stat_main.jl
@@ -1,7 +1,7 @@
 include("rw_stat.jl")
 
-dim = length(ARGS)>0 ? parse(ARGS[1]) : 1
-num = length(ARGS)>1 ? parse(ARGS[2]) : 1000
+dim = length(ARGS)>0 ? parse(Int, ARGS[1]) : 1
+num = length(ARGS)>1 ? parse(Int, ARGS[2]) : 1000
 nsteps = length(ARGS)>2 ? parse(Int, ARGS[3]) : 1000
 filename = length(ARGS)>3 ? ARGS[4] : ""
 


### PR DESCRIPTION
`parse` 関数の以下のエラーの修正です。

```sh
$ julia src/rw_1d_stat_main.jl 10 10 0.4
ERROR: LoadError: MethodError: no method matching parse(::String)
Closest candidates are:
  parse(!Matched::Type{T<:Integer}, !Matched::AbstractChar; base) where T<:Integer at parse.jl:38
  parse(!Matched::Type{LibGit2.GitCredential}, !Matched::AbstractString) at /Users/osx/buildbot/slave/package_osx64/build/usr/share/julia/stdlib/v1.0/LibGit2/src/gitcredential.jl:71
  parse(!Matched::Type{LibGit2.GitCredentialHelper}, !Matched::AbstractString) at /Users/osx/buildbot/slave/package_osx64/build/usr/share/julia/stdlib/v1.0/LibGit2/src/gitcredential.jl:158
  ...
Stacktrace:
 [1] top-level scope at none:0
 [2] include at ./boot.jl:317 [inlined]
 [3] include_relative(::Module, ::String) at ./loading.jl:1038
 [4] include(::Module, ::String) at ./sysimg.jl:29
 [5] exec_options(::Base.JLOptions) at ./client.jl:229
 [6] _start() at ./client.jl:421
in expression starting at JuliaBook-Samples/src/rw_1d_stat_main.jl:3
```